### PR TITLE
Bump gemspec version

### DIFF
--- a/lib/ok_health_check/version.rb
+++ b/lib/ok_health_check/version.rb
@@ -1,3 +1,3 @@
 module OkHealthCheck
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
## Why?
Some changes to the gemspec need to be propagated to
RubyGems so that it's up-to-date.

## What's changed:
**Refactor gemspec**
  1.0.0 -> 1.0.1